### PR TITLE
updated policy construction

### DIFF
--- a/log_group_permissions_demo/log_group_permissions_demo_stack.py
+++ b/log_group_permissions_demo/log_group_permissions_demo_stack.py
@@ -22,19 +22,22 @@ class LogGroupPermissionsDemoStack(core.Stack):
     ) -> None:
         """Construct a new LogGroupPermissionsDemoStack."""
         super().__init__(scope, construct_id, **kwargs)
+
         role = iam.Role(
             scope=self,
             id="Role",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
         )
-
-        role.add_to_policy(
-            iam.PolicyStatement(
+        
+        statement = iam.PolicyStatement(
                 actions=["logs:PutLogEvents", "logs:CreateLogStream"],
                 effect=iam.Effect.ALLOW,
                 resources=["*"],
             )
-        )
+        
+        log_policy = iam.Policy(scope=self, id='Policy')
+        log_policy.add_statements(statement)
+        log_policy.attach_to_role(role)
 
         function = lambda_.Function(
             scope=self,

--- a/log_group_permissions_demo/log_group_permissions_demo_stack.py
+++ b/log_group_permissions_demo/log_group_permissions_demo_stack.py
@@ -28,16 +28,6 @@ class LogGroupPermissionsDemoStack(core.Stack):
             id="Role",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
         )
-        
-        statement = iam.PolicyStatement(
-                actions=["logs:PutLogEvents", "logs:CreateLogStream"],
-                effect=iam.Effect.ALLOW,
-                resources=["*"],
-            )
-        
-        log_policy = iam.Policy(scope=self, id='Policy')
-        log_policy.add_statements(statement)
-        log_policy.attach_to_role(role)
 
         function = lambda_.Function(
             scope=self,
@@ -47,3 +37,16 @@ class LogGroupPermissionsDemoStack(core.Stack):
             handler="index.handler",
             role=role,
         )
+        
+        statement = iam.PolicyStatement(
+                actions=["logs:PutLogEvents", "logs:CreateLogStream"],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    f'arn:aws:logs:{self.region}:{self.account}:log-group:/aws/lambda/{function.function_name}:log-stream:*'],
+        )
+        
+        log_policy = iam.Policy(
+            scope=self, id='Policy',
+            document=iam.PolicyDocument(statements=[statement])
+        )
+        log_policy.attach_to_role(role)


### PR DESCRIPTION
```
  Policy23B91518:
    Type: AWS::IAM::Policy
    Properties:
      PolicyDocument:
        Statement:
          - Action:
              - logs:PutLogEvents
              - logs:CreateLogStream
            Effect: Allow
            Resource: "*"
        Version: "2012-10-17"
      PolicyName: Policy23B91518
      Roles:
        - Ref: Role1ABCC5F0
    Metadata:
      aws:cdk:path: LogGroupPermissionsDemoStack/Policy/Resource
  Function76856677:
    Type: AWS::Lambda::Function
    Properties:
      Code:
        ZipFile: print('Hello World')
      Role:
        Fn::GetAtt:
          - Role1ABCC5F0
          - Arn
      Handler: index.handler
      Runtime: python3.8
    DependsOn:
      - Role1ABCC5F0
    Metadata:
      aws:cdk:path: LogGroupPermissionsDemoStack/Function/Resource
```